### PR TITLE
feat: issue_duration_in_status is now idempotent, adds release

### DIFF
--- a/python/jira_issue_duration_in_status.py
+++ b/python/jira_issue_duration_in_status.py
@@ -2,32 +2,35 @@
 
 from jira import JIRA
 from util import get_settings
-from jira_sql_dao import insert_into_issue_duration_in_status
+from jira_sql_dao import insert_into_issue_duration_in_status, delete_planning_period
 from jira_utils import get_statuses_and_time_spent_in
-import sys
-import datetime
 
 settings = get_settings()
 options = { 'server': settings["jira"]["server"] }
 jira = JIRA(options, basic_auth=(settings["jira"]["user"], settings["jira"]["password"]))
 
-def get_counts_for_period(period, team):
+def update_counts_for_period(period, team):
     JQL = f"project = CLM AND fixVersion = '{period}' AND Team = {team}"
     issues = jira.search_issues(JQL, maxResults=500)
-    print(period, team, issues.total, issues.maxResults, sep=", ")
+    if issues.total == 500:
+        print(f"WARNING: hit maxResults for {period} and {team}")
 
+
+    delete_planning_period(period, team)
     for issue in issues:
         iType = issue.fields.issuetype.name
         if iType == 'Bug' and 'Nexus IQ:' in issue.fields.summary:
             iType = 'Policy'
-
+        elif issue.fields.summary.startswith('Release IQ '):
+            iType = 'Release'
         insert_into_issue_duration_in_status(period, team, issue.key, iType, get_statuses_and_time_spent_in(jira, issue))
 
 planningPeriods = settings['planningPeriods']
 
 for team in [17, 18, 35, 36, 38]:
     for period in planningPeriods:
-        get_counts_for_period(period, team)
-#get_counts_for_period('Joy', 35)
+        print(f"started planning period {period} and team {team}...")
+        update_counts_for_period(period, team)
+        print(f"completed planning period {period} and team {team}")
 
     

--- a/python/jira_sql_dao.py
+++ b/python/jira_sql_dao.py
@@ -27,12 +27,17 @@ def insert_into_time_in_status(version, issueType, team, status_name, count, the
         # your changes.
         connection.commit()
 
-        # with connection.cursor() as cursor:
-        #     # Read a single record
-        #     sql = "SELECT `id`, `password` FROM `users` WHERE `email`=%s"
-        #     cursor.execute(sql, ('webmaster@python.org',))
-        #     result = cursor.fetchone()
-        #     print(result)
+    finally:
+        connection.close()
+
+def delete_planning_period(planning_period, team):
+    connection = get_connection()
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("delete from issue_duration_in_status where planning_period = %s and team = %s", (planning_period, team))
+
+        connection.commit()
+
     finally:
         connection.close()
 


### PR DESCRIPTION
This change allows us to re-run the script repeatedly for the same planning period; it accomplishes this by deleting the related rows before re-inserting.
This change set also includes a new issue_type called "Release" and depends on the main release stories starting with "Release IQ" as they do from the template.

Minor: renamed 'get_counts_for_period' to 'update_counts_for_period' to reflect it's nature to write.